### PR TITLE
#4; Added tag list to root Document

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,27 @@ document {
 }
 ```
 
+
+### Adding Tags 
+
+Usually tags is a list of `Tag Object` you can create/append to list of 
+tags by using `tag {}`
+
+```kotlin
+document {
+    tag {
+        name { "tag name" }
+        description { "tag description" }
+        doc {
+            url { "" }
+            description { "" }
+        }
+    }
+}
+```
+
+ - `name` is **required**
+
 ### Converting document to JSON
 
 ```kotlin

--- a/src/main/kotlin/Document.kt
+++ b/src/main/kotlin/Document.kt
@@ -18,7 +18,7 @@ data class Document (
     val paths: Map<String, Path> = mapOf(),
     val components: Component? = null,
     val security: SecurityRequirement? = null,
-    val tags: Tag? = null,
+    val tags: List<Tag>? = null,
     val externalDocs: ExternalDocumentation? = null
 ) {
     fun yaml(): String {
@@ -40,6 +40,9 @@ class DocumentBuilder {
     private var info: Info = Info("", "", "", Contact(), License(""), "")
     private var servers: ArrayList<Server> = arrayListOf()
     private var paths: MutableMap<String, Path> = mutableMapOf()
+    private var components: Component? = null
+    private var security: SecurityRequirement? = null
+    private var tags: ArrayList<Tag>? = null
 
     fun openapi(block: () -> String) {
         this.openapi = block()
@@ -57,7 +60,14 @@ class DocumentBuilder {
         paths.put(url, PathBuilder().apply(block).build())
     }
 
-    fun build() = Document(openapi, info, servers, paths)
+    fun tag(block: TagBuilder.() -> Unit) {
+        if(tags.isNullOrEmpty()) {
+            tags = arrayListOf()
+        }
+        tags!!.add(TagBuilder().apply(block).build())
+    }
+
+    fun build() = Document(openapi, info, servers, paths, components, security, tags)
 }
 
 fun document(block: DocumentBuilder.() -> Unit): Document {

--- a/src/main/kotlin/Tag.kt
+++ b/src/main/kotlin/Tag.kt
@@ -5,3 +5,17 @@ data class Tag(
     val description: String? = null,
     val externalDocs: ExternalDocumentation? = null
 )
+
+class TagBuilder {
+    private var name: String = ""
+    private var description: String? = null
+    private var externalDocs: ExternalDocumentation? = null
+
+    fun name(block: () -> String) { name = block() }
+    fun description(block: () -> String) { description = block() }
+    fun doc(block: ExternalDocumentationBuilder.() -> Unit) {
+        externalDocs = ExternalDocumentationBuilder().apply(block).build()
+    }
+
+    fun build() = Tag(name, description, externalDocs)
+}

--- a/src/test/kotlin/DocumentTest.kt
+++ b/src/test/kotlin/DocumentTest.kt
@@ -1,51 +1,11 @@
 package com.schehata.oas3.test
 
-import io.kotlintest.matchers.maps.shouldContainValue
 import io.kotlintest.specs.AnnotationSpec
-import main.document
 
 class DocumentTest: AnnotationSpec() {
     @Test
     fun `Creating a Document should succeed`() {
-        val d = document {
-            openapi { "3" }
-            info {
-                title { "OpenAPI 3 Spec" }
-                version { "1.0.0" }
-                contact {
-                    name { "Islam Shehata" }
-                    email { "schehata@icloud.com" }
-                }
-                license {
-                    name { "GPL 3" }
-                }
-            }
-            server {
-                url { "api.schehata.com" }
-                description { "server description" }
-            }
-            server {
-                url { "sandbox.schehata.com" }
-                description { "Testing Server" }
-            }
-            path("/status") {
-                get {
-                    tag { "tag1" }
-                    tag { "tag2" }
-                    summary { "GET request" }
-                    description { "TOO much to write for a desc" }
-                    operationId { "getStatus" }
-                    deprecated { true }
-
-                }
-                post {
-                    tag { "tag1" }
-                    summary { "GET request" }
-                    description { "TOO much to write for a desc" }
-                    operationId { "postStatus" }
-                }
-            }
-        }
+        val d = validDocument
 
         assert(d.openapi == "3")
         assert(d.servers?.count() == 2)
@@ -54,5 +14,13 @@ class DocumentTest: AnnotationSpec() {
         assert(d.info.contact?.name == "Islam Shehata")
         assert(d.paths.count() == 1)
         assert(d.paths.containsKey("/status"))
+    }
+
+    fun `Document Tags should contains correct values`() {
+        assert(validDocument.tags?.count() == 1)
+        val tag = validDocument.tags!!.get(0)!!
+        assert(tag.name == "Document Tag")
+        assert(tag.description!!.isNotBlank())
+        assert(tag.externalDocs!!.url.isNotBlank())
     }
 }

--- a/src/test/kotlin/valid_document.kt
+++ b/src/test/kotlin/valid_document.kt
@@ -1,0 +1,50 @@
+package com.schehata.oas3.test
+
+import main.document
+
+val validDocument = document {
+    openapi { "3" }
+    info {
+        title { "OpenAPI 3 Spec" }
+        version { "1.0.0" }
+        contact {
+            name { "Islam Shehata" }
+            email { "schehata@icloud.com" }
+        }
+        license {
+            name { "GPL 3" }
+        }
+    }
+    tag {
+        name { "Document Tag"}
+        description { "Description of the document tag" }
+        doc {
+            url { "http://spec.openapis.org/oas/v3.0.2#tagObject" }
+        }
+    }
+    server {
+        url { "api.schehata.com" }
+        description { "server description" }
+    }
+    server {
+        url { "sandbox.schehata.com" }
+        description { "Testing Server" }
+    }
+    path("/status") {
+        get {
+            tag { "tag1" }
+            tag { "tag2" }
+            summary { "GET request" }
+            description { "TOO much to write for a desc" }
+            operationId { "getStatus" }
+            deprecated { true }
+
+        }
+        post {
+            tag { "tag1" }
+            summary { "GET request" }
+            description { "TOO much to write for a desc" }
+            operationId { "postStatus" }
+        }
+    }
+}


### PR DESCRIPTION
Created `Tag Builder` and added it's functionality to `DocumentBuilder`, now users are able
to create/append to `tags` list by using this `tag {}` inside the `document {}`.